### PR TITLE
fix: 修正重定向目标为/index.html，并将状态码更改为301

### DIFF
--- a/edgeone.json
+++ b/edgeone.json
@@ -17,8 +17,8 @@
   "redirects": [
     {
       "source": "/",
-      "destination": "/index",
-      "statusCode": 302
+      "destination": "/index.html",
+      "statusCode": 301
     }
   ]
 }


### PR DESCRIPTION
This pull request updates the root redirect configuration in `edgeone.json` to improve SEO and ensure correct routing.

Redirect configuration update:

* Changed the redirect destination from `/index` to `/index.html` and updated the status code from `302` (temporary) to `301` (permanent) for the root path `/` in `edgeone.json`.